### PR TITLE
Schema and network connect improvements

### DIFF
--- a/ldap/client/api/src/main/java/org/apache/directory/ldap/client/api/DefaultSchemaLoader.java
+++ b/ldap/client/api/src/main/java/org/apache/directory/ldap/client/api/DefaultSchemaLoader.java
@@ -103,7 +103,6 @@ public class DefaultSchemaLoader extends AbstractSchemaLoader
     private static NormalizerDescriptionSchemaParser N_DESCR_SCHEMA_PARSER = new NormalizerDescriptionSchemaParser();
     private static SyntaxCheckerDescriptionSchemaParser SC_DESCR_SCHEMA_PARSER = new SyntaxCheckerDescriptionSchemaParser();
 
-
     /**
      * Creates a new instance of DefaultSchemaLoader.
      *
@@ -113,12 +112,27 @@ public class DefaultSchemaLoader extends AbstractSchemaLoader
      */
     public DefaultSchemaLoader( LdapConnection connection ) throws LdapException
     {
+        this( connection, false );
+    }
+
+    /**
+     * Creates a new instance of DefaultSchemaLoader.
+     *
+     * @param connection the LDAP connection
+     * @param initial setting for the quirks mode
+     * @throws Exception if the connection is not authenticated or if there are any problems
+     *                   while loading the schema entries
+     */
+    public DefaultSchemaLoader( LdapConnection connection, boolean quirksMode ) throws LdapException
+    {
         if ( connection == null )
         {
             throw new InvalidConnectionException( "Cannot connect on the server, the connection is null" );
         }
 
         this.connection = connection;
+
+        setQuirksMode(quirksMode);
 
         // Flagging if the connection was already connected
         boolean wasConnected = connection.isConnected();
@@ -1121,5 +1135,28 @@ public class DefaultSchemaLoader extends AbstractSchemaLoader
         }
 
         return entry;
+    }
+
+    /**
+     * Sets the quirks mode for all the internal parsers.
+     * 
+     * If enabled the parser accepts non-numeric OIDs and some
+     * special characters in descriptions.
+     * 
+     * @param enabled the new quirks mode
+     */
+    public void setQuirksMode( boolean enabled )
+    {
+        AT_DESCR_SCHEMA_PARSER.setQuirksMode( enabled );
+        C_DESCR_SCHEMA_PARSER.setQuirksMode( enabled );
+        DCR_DESCR_SCHEMA_PARSER.setQuirksMode( enabled );
+        DSR_DESCR_SCHEMA_PARSER.setQuirksMode( enabled );
+        LS_DESCR_SCHEMA_PARSER.setQuirksMode( enabled );
+        MR_DESCR_SCHEMA_PARSER.setQuirksMode( enabled );
+        MRU_DESCR_SCHEMA_PARSER.setQuirksMode( enabled );
+        N_DESCR_SCHEMA_PARSER.setQuirksMode( enabled );
+        NF_DESCR_SCHEMA_PARSER.setQuirksMode( enabled );
+        OC_DESCR_SCHEMA_PARSER.setQuirksMode( enabled );
+        SC_DESCR_SCHEMA_PARSER.setQuirksMode( enabled );
     }
 }

--- a/ldap/client/api/src/main/java/org/apache/directory/ldap/client/api/LdapNetworkConnection.java
+++ b/ldap/client/api/src/main/java/org/apache/directory/ldap/client/api/LdapNetworkConnection.java
@@ -25,6 +25,7 @@ import static org.apache.directory.api.ldap.model.message.ResultCodeEnum.process
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.net.ConnectException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.nio.channels.UnresolvedAddressException;
@@ -549,6 +550,7 @@ public class LdapNetworkConnection extends AbstractLdapConnection implements Lda
         SocketAddress address = new InetSocketAddress( config.getLdapHost(), config.getLdapPort() );
 
         // And create the connection future
+        timeout = config.getTimeout();
         long maxRetry = System.currentTimeMillis() + timeout;
         ConnectFuture connectionFuture = null;
 
@@ -557,7 +559,6 @@ public class LdapNetworkConnection extends AbstractLdapConnection implements Lda
             connectionFuture = connector.connect( address );
 
             boolean result = false;
-            timeout = config.getTimeout();
 
             // Wait until it's established
             try
@@ -581,8 +582,14 @@ public class LdapNetworkConnection extends AbstractLdapConnection implements Lda
 
                     if ( !isConnected )
                     {
-                        LOG.debug( "------>>   Cannot get the connection... Retrying" );
-
+                        if (connectionFuture.getException() instanceof ConnectException) {
+                            // No need to wait. 
+                            // We know that there was a permanent error such as "connection refused".
+                            LOG.debug( "------>>   Connection error: {}", connectionFuture.getException().getMessage());
+                            break;
+                        }
+                        LOG.debug( "------>>   Cannot get the connection ... Retrying");
+                        
                         // Wait 500 ms and retry
                         try
                         {
@@ -629,7 +636,7 @@ public class LdapNetworkConnection extends AbstractLdapConnection implements Lda
 
             if ( e != null )
             {
-                StringBuilder message = new StringBuilder( "Cannot connect on the server: " );
+                StringBuilder message = new StringBuilder( "Cannot connect to the server: " );
 
                 // Special case for UnresolvedAddressException
                 // (most of the time no message is associated with this exception)

--- a/ldap/model/src/main/java/org/apache/directory/api/ldap/model/schema/DitStructureRule.java
+++ b/ldap/model/src/main/java/org/apache/directory/api/ldap/model/schema/DitStructureRule.java
@@ -208,14 +208,15 @@ public class DitStructureRule extends AbstractSchemaObject
 
 
     /**
-     * The DIT structure rule does not have an OID, so this implementations always throws an exception.
+     * The DIT structure rule does not have an OID.
      * 
      * {@inheritDoc}
      */
     @Override
     public String getOid()
     {
-        throw new NotImplementedException();
+        // We cannot throw exception here. E.g. SchemaObjectWrapper will try to use this in hashcode.
+        return null;
     }
 
 

--- a/ldap/model/src/main/java/org/apache/directory/api/ldap/model/schema/SchemaObjectWrapper.java
+++ b/ldap/model/src/main/java/org/apache/directory/api/ldap/model/schema/SchemaObjectWrapper.java
@@ -53,7 +53,10 @@ public class SchemaObjectWrapper
     {
         int h = 37;
         h += h * 17 + schemaObject.getObjectType().getValue();
-        h += h * 17 + schemaObject.getOid().hashCode();
+        if ( schemaObject.getOid() != null )
+        {
+            h += h * 17 + schemaObject.getOid().hashCode();
+        }
 
         return h;
     }
@@ -77,7 +80,18 @@ public class SchemaObjectWrapper
         SchemaObject that = ( ( SchemaObjectWrapper ) o ).get();
         SchemaObject current = get();
 
-        return ( that.getOid().equals( current.getOid() ) && ( that.getObjectType() == current.getObjectType() ) );
+        if ( that.getOid() == null && current.getOid() != null )
+        {
+            return false;
+        }
+
+        if ( current.getOid() == null && that.getOid() != null )
+        {
+            return false;
+        }
+
+        return ( ( ( that.getOid() == null && current.getOid() == null )
+                    || that.getOid().equals( current.getOid() ) ) && ( that.getObjectType() == current.getObjectType() ) );
     }
 
 


### PR DESCRIPTION
Fixing NPEs with uknown schema objects (tested with OpenDJ).
Ability to set quirks mode in DefaultSchemaLoader.
Fixed handling of timeout in LdapNetworkConnection.connect(). Also "quick exit" for ConnectException.